### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ About
 A native Kerberos client implementation for Python on Windows. This module
 mimics the API of `pykerberos <https://pypi.python.org/pypi/pykerberos>`_ to
 implement Kerberos authentication with Microsoft's Security Support Provider
-Interface (SSPI). It supports Python 2.6, 2.7, and 3.3+.
+Interface (SSPI). It supports Python 2.7 and 3.4+.
 
 Installation
 ============
@@ -29,9 +29,7 @@ Building and installing from source
 You must have the correct version of VC++ installed for your version of
 Python:
 
-- Python 2.6 - `Microsoft Visual C++ Compiler for Python 2.7`_
 - Python 2.7 - `Microsoft Visual C++ Compiler for Python 2.7`_
-- Python 3.3 - Visual Studio 2010 (Professional for 64bit)
 - Python 3.4 - Visual Studio 2010 (Professional for 64bit)
 - Python 3.5+ - Visual Studio 2015 (Any version)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,9 +32,7 @@ Building and installing from source
 You must have the correct version of VC++ installed for your version of
 Python:
 
-- Python 2.6 - `Microsoft Visual C++ Compiler for Python 2.7`_
 - Python 2.7 - `Microsoft Visual C++ Compiler for Python 2.7`_
-- Python 3.3 - Visual Studio 2010 (Professional for 64bit)
 - Python 3.4 - Visual Studio 2010 (Professional for 64bit)
 - Python 3.5+ - Visual Studio 2015 (Any version)
 

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -315,7 +315,13 @@ def _extractall(self, path=".", members=None):
         self.extract(tarinfo, path)
 
     # Reverse sort directories.
-    directories.sort(key=operator.attrgetter('name'), reverse=True)
+    if sys.version_info < (2, 4):
+        def sorter(dir1, dir2):
+            return cmp(dir1.name, dir2.name)
+        directories.sort(sorter)
+        directories.reverse()
+    else:
+        directories.sort(key=operator.attrgetter('name'), reverse=True)
 
     # Set correct owner, mtime and filemode on directories.
     for tarinfo in directories:
@@ -338,6 +344,9 @@ def _build_install_args(options):
     """
     install_args = []
     if options.user_install:
+        if sys.version_info < (2, 6):
+            log.warn("--user requires Python 2.6 or later")
+            raise SystemExit(1)
         install_args.append('--user')
     return install_args
 
@@ -348,7 +357,7 @@ def _parse_args():
     parser = optparse.OptionParser()
     parser.add_option(
         '--user', dest='user_install', action='store_true', default=False,
-        help='install in user site package')
+        help='install in user site package (requires Python 2.6 or later)')
     parser.add_option(
         '--download-base', dest='download_base', metavar="URL",
         default=DEFAULT_URL,

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -315,13 +315,7 @@ def _extractall(self, path=".", members=None):
         self.extract(tarinfo, path)
 
     # Reverse sort directories.
-    if sys.version_info < (2, 4):
-        def sorter(dir1, dir2):
-            return cmp(dir1.name, dir2.name)
-        directories.sort(sorter)
-        directories.reverse()
-    else:
-        directories.sort(key=operator.attrgetter('name'), reverse=True)
+    directories.sort(key=operator.attrgetter('name'), reverse=True)
 
     # Set correct owner, mtime and filemode on directories.
     for tarinfo in directories:
@@ -344,9 +338,6 @@ def _build_install_args(options):
     """
     install_args = []
     if options.user_install:
-        if sys.version_info < (2, 6):
-            log.warn("--user requires Python 2.6 or later")
-            raise SystemExit(1)
         install_args.append('--user')
     return install_args
 
@@ -357,7 +348,7 @@ def _parse_args():
     parser = optparse.OptionParser()
     parser.add_option(
         '--user', dest='user_install', action='store_true', default=False,
-        help='install in user site package (requires Python 2.6 or later)')
+        help='install in user site package')
     parser.add_option(
         '--download-base', dest='download_base', metavar="URL",
         default=DEFAULT_URL,

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     tests_require=tests_require,
     platforms="Windows",
     license="Apache License, Version 2.0",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -76,11 +76,6 @@ with open("README.rst") as f:
         readme = ""
 
 tests_require = ["pymongo >= 2.9"]
-if sys.version_info[:2] == (2, 6):
-    tests_require.append("unittest2 >= 0.5.1")
-    test_suite = "unittest2.collector"
-else:
-    test_suite = "test"
 
 chost = os.environ.get("MINGW_CHOST") #ie: i686-w64-mingw32
 if chost:
@@ -106,7 +101,7 @@ setup(
     url="https://github.com/mongodb-labs/winkerberos",
     keywords=["Kerberos", "SSPI", "GSSAPI"],
     install_requires=[],
-    test_suite=test_suite,
+    test_suite="test",
     tests_require=tests_require,
     platforms="Windows",
     license="Apache License, Version 2.0",
@@ -116,10 +111,8 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@
 import os
 import sys
 
+if sys.version_info[:2] < (2, 7):
+    raise RuntimeError("Python version >= 2.7 required.")
+
 # http://bugs.python.org/issue15881
 try:
     import multiprocessing

--- a/src/winkerberos.c
+++ b/src/winkerberos.c
@@ -21,15 +21,10 @@
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_FromLong PyLong_FromLong
 #define PyString_FromString PyUnicode_FromString
-#endif
-
-#if PY_VERSION_HEX >= 0x03020000
 #define PyCObject_Check PyCapsule_CheckExact
 #define PyCObject_FromVoidPtr(cobj, destr) PyCapsule_New(cobj, NULL, destr)
 #define PyCObject_AsVoidPtr(self) PyCapsule_GetPointer(self, NULL)
-#endif
-
-#if PY_VERSION_HEX < 0x03030000
+#else
 #define PyUnicode_GET_LENGTH PyUnicode_GET_SIZE
 #endif
 

--- a/test/test_winkerberos.py
+++ b/test/test_winkerberos.py
@@ -247,12 +247,12 @@ class TestWinKerberos(unittest.TestCase):
         try:
             self.authenticate(password=password)
         except kerberos.GSSError as exc:
-            self.fail("Failed bytearray: %s" % (str(exc),))
+            self.fail("Failed bytearray: {}".format(str(exc)))
 
         try:
             self.authenticate(password=memoryview(password))
         except kerberos.GSSError as exc:
-            self.fail("Failed memoryview: %s" % (str(exc),))
+            self.fail("Failed memoryview: {}".format(str(exc)))
 
         # mmap.mmap and array.array only expose the
         # buffer interface in python 3.x
@@ -263,7 +263,7 @@ class TestWinKerberos(unittest.TestCase):
             try:
                 self.authenticate(password=mm)
             except kerberos.GSSError as exc:
-                self.fail("Failed map.map: %s" % (str(exc),))
+                self.fail("Failed map.map: {}".format(str(exc)))
 
             # Note that only ascii and utf8 strings are supported, so
             # 'u' with a unicode object won't work. Unicode objects
@@ -271,7 +271,7 @@ class TestWinKerberos(unittest.TestCase):
             try:
                 self.authenticate(password=array.array('b', password))
             except kerberos.GSSError as exc:
-                self.fail("Failed array.array: %s" % (str(exc),))
+                self.fail("Failed array.array: {}".format(str(exc)))
 
     def test_principal(self):
         if _PRINCIPAL is None:
@@ -280,7 +280,7 @@ class TestWinKerberos(unittest.TestCase):
             self.authenticate(
                 principal=_PRINCIPAL, user=None, domain=None, password=None)
         except kerberos.GSSError as exc:
-            self.fail("Failed testing principal: %s" % (str(exc),))
+            self.fail("Failed testing principal: {}".format(str(exc)))
 
         encoded = bytearray(_PRINCIPAL, "utf8")
         # No error.

--- a/test/test_winkerberos.py
+++ b/test/test_winkerberos.py
@@ -17,11 +17,7 @@ import base64
 import mmap
 import os
 import sys
-
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 sys.path[0:0] = [""]
 
@@ -253,12 +249,10 @@ class TestWinKerberos(unittest.TestCase):
         except kerberos.GSSError as exc:
             self.fail("Failed bytearray: %s" % (str(exc),))
 
-        # memoryview doesn't exist in python 2.6
-        if sys.version_info[:2] >= (2, 7):
-            try:
-                self.authenticate(password=memoryview(password))
-            except kerberos.GSSError as exc:
-                self.fail("Failed memoryview: %s" % (str(exc),))
+        try:
+            self.authenticate(password=memoryview(password))
+        except kerberos.GSSError as exc:
+            self.fail("Failed memoryview: %s" % (str(exc),))
 
         # mmap.mmap and array.array only expose the
         # buffer interface in python 3.x


### PR DESCRIPTION
Fixes #26, fixes #27.

https://github.com/mongodb-labs/winkerberos/issues/26 says:

> * Remove all uses of PyCObject (PyCapsule is available in Python 2.7)

I didn't do this as I'm not so familiar with the needed changes.

Also Python 3.4 is EOL on 2019-03-16 so you may want to drop that as well now or soon.

* https://en.wikipedia.org/wiki/CPython#Version_history