### PR TITLE
ci: declare contents:read on build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   static:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block. The build job checks out the repository (including submodules), installs the toolchain, then invokes `cmake` and the platform-native build to produce binaries. None of those steps call a GitHub API beyond the initial checkout.

The runtime supply-chain threat that this caps is the one CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) demonstrated. A tampered third-party action exfiltrates `GITHUB_TOKEN` from workflow logs and the leaked token retains whatever scope was issued at the workflow level. With `contents: read` declared in-file, any action - present or future - that runs in this workflow is bounded to read access, regardless of whatever the org default is set to. OpenSSF Scorecard's Token-Permissions check only credits the explicit per-workflow declaration.

YAML validated locally with `yaml.safe_load`.
